### PR TITLE
Add Cloudflare Pages config for dotfiles

### DIFF
--- a/cfpages-dotfiles-utf9k-net.tf
+++ b/cfpages-dotfiles-utf9k-net.tf
@@ -1,0 +1,35 @@
+resource "cloudflare_pages_project" "dotfiles-utf9k-net" {
+  account_id        = var.cloudflare_account_id
+  name              = "dotfiles"
+  production_branch = "main"
+  build_config {
+    destination_dir = "public"
+    root_dir        = "/"
+  }
+  deployment_configs {
+    preview {
+      compatibility_date        = "2022-12-25"
+      compatibility_flags       = []
+      d1_databases              = {}
+      durable_object_namespaces = {}
+      environment_variables     = {}
+      kv_namespaces             = {}
+      r2_buckets                = {}
+    }
+    production {
+      compatibility_date        = "2022-12-25"
+      compatibility_flags       = []
+      d1_databases              = {}
+      durable_object_namespaces = {}
+      environment_variables     = {}
+      kv_namespaces             = {}
+      r2_buckets                = {}
+    }
+  }
+}
+
+resource "cloudflare_pages_domain" "dotfiles-utf9k-net" {
+  account_id   = var.cloudflare_account_id
+  project_name = "dotfiles"
+  domain       = "dotfiles.utf9k.net"
+}


### PR DESCRIPTION
This PR sets up resources for moving `dotfiles.utf9k.net` over to Cloudflare Pages but doesn't yet cut over any DNS records