### PR TITLE
Fix up drift with utf9k.net resources

### DIFF
--- a/cfpages-utf9k-net.tf
+++ b/cfpages-utf9k-net.tf
@@ -48,6 +48,6 @@ resource "cloudflare_worker_script" "statistician" {
 
 resource "cloudflare_worker_route" "utf9k" {
   zone_id     = "2117c58a86ea651fc35e585881e42c6e"
-  pattern     = "*.utf9k.net/*"
+  pattern     = "*.utf9k.net/workers/*"
   script_name = cloudflare_worker_script.statistician.name
 }

--- a/cfpages-utf9k-net.tf
+++ b/cfpages-utf9k-net.tf
@@ -48,6 +48,6 @@ resource "cloudflare_worker_script" "statistician" {
 
 resource "cloudflare_worker_route" "utf9k" {
   zone_id     = "2117c58a86ea651fc35e585881e42c6e"
-  pattern     = "*.utf9k.net/workers/*"
+  pattern     = "utf9k.net/workers/*"
   script_name = cloudflare_worker_script.statistician.name
 }

--- a/dns-utf9k-net.tf
+++ b/dns-utf9k-net.tf
@@ -9,9 +9,10 @@ resource "cloudflare_zone" "utf9k-net-zone" {
 resource "cloudflare_record" "cname-utf9k-net" {
   zone_id = cloudflare_zone.utf9k-net-zone.id
   name    = "utf9k.net"
+  proxied = true
   value   = "utf9k.pages.dev"
   type    = "CNAME"
-  ttl     = 3600
+  ttl     = 1
 }
 
 resource "cloudflare_record" "cname-dotfiles-utf9k-net" {
@@ -57,9 +58,10 @@ resource "cloudflare_record" "cname-towing-utf9k-net" {
 resource "cloudflare_record" "cname-www-utf9k-net" {
   zone_id = cloudflare_zone.utf9k-net-zone.id
   name    = "www.utf9k.net"
+  proxied = true
   value   = "utf9k.net"
   type    = "CNAME"
-  ttl     = 3600
+  ttl     = 1
 }
 
 ## Mail


### PR DESCRIPTION
This PR does the following:

- Fixes worker route (`/` -> `/worker/`)
- Adds explicit `proxied: true` for apex and `www` records