### PR TITLE
Add home.utf9k.net zone and initial record for Synology NAS

### DIFF
--- a/dns-home-utf9k-net.tf
+++ b/dns-home-utf9k-net.tf
@@ -1,0 +1,15 @@
+resource "cloudflare_zone" "home-utf9k-net-zone" {
+  account_id = var.cloudflare_account_id
+  zone       = "home.utf9k.net"
+}
+
+# CNAME Records
+
+## Synology NAS
+resource "cloudflare_record" "a-home-utf9k-net" {
+  zone_id = cloudflare_zone.home-utf9k-net-zone.id
+  name    = "home.utf9k.net"
+  value   = "158.140.244.234"
+  type    = "A"
+  ttl     = 3600
+}


### PR DESCRIPTION
This PR adds records for my Synology NAS now that I have a static IP address for my house.

Living on the edge exposing things to the public internet etc etc